### PR TITLE
feat: upgrade OpenFga.Sdk to 0.2.0

### DIFF
--- a/src/Fga.Net.AspNetCore/Authorization/FineGrainedAuthorizationHandler.cs
+++ b/src/Fga.Net.AspNetCore/Authorization/FineGrainedAuthorizationHandler.cs
@@ -69,8 +69,8 @@ internal class FineGrainedAuthorizationHandler : AuthorizationHandler<FineGraine
                     _logger.NullValuesReturned(user, relation, @object);
                     return;
                 }
-               
-                
+
+
                 var result = await _client.Check(new CheckRequest()
                 {
                     TupleKey = new TupleKey
@@ -81,7 +81,7 @@ internal class FineGrainedAuthorizationHandler : AuthorizationHandler<FineGraine
                     }
                 }, httpContext.RequestAborted);
 
-                if (!result.Allowed)
+                if (!result.Allowed.HasValue || ! result.Allowed.Value)
                 {
                     _logger.CheckFailureDebug(user, relation, @object);
                     return;

--- a/src/Fga.Net.AspNetCore/Controllers/FgaControllerBase.cs
+++ b/src/Fga.Net.AspNetCore/Controllers/FgaControllerBase.cs
@@ -29,7 +29,7 @@ public class FgaControllerBase : ControllerBase
 {
     private readonly OpenFgaApi _client;
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="client"></param>
     public FgaControllerBase(OpenFgaApi client)
@@ -38,7 +38,7 @@ public class FgaControllerBase : ControllerBase
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="user"></param>
     /// <param name="relation"></param>
@@ -56,6 +56,6 @@ public class FgaControllerBase : ControllerBase
                 Object = @object
             }
         }, ct);
-        return checkRes.Allowed;
+        return checkRes.Allowed.HasValue && checkRes.Allowed.Value;
     }
 }

--- a/src/Fga.Net/Fga.Net.DependencyInjection.csproj
+++ b/src/Fga.Net/Fga.Net.DependencyInjection.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="OpenFga.Sdk" Version="0.1.0" />
+    <PackageReference Include="OpenFga.Sdk" Version="0.2.0" />
   </ItemGroup>
 
   <Import Project="../../Package.Build.props" />


### PR DESCRIPTION
The OpenFga SDK to version 0.2.0 includes support for OpenFGA 0.3.0 (see [release](https://github.com/openfga/dotnet-sdk/releases/tag/v0.2.0) for more details).